### PR TITLE
Update frontier_user_guide.rst

### DIFF
--- a/systems/frontier_user_guide.rst
+++ b/systems/frontier_user_guide.rst
@@ -3218,3 +3218,10 @@ Known Issues
 ============
 
 .. JIRA_CONTENT_HERE
+
+
+Office Hours
+============
+Would your project team like direct access to OLCF, AMD, and HPE staff for current issues or questions you might have about running your application/software on Frontier? If so, we are offering office hours every Monday from 2-3 PM EST and Wednesday from 1-2 PM EST. During each session, (up to) 5 teams will move into their own Zoom breakout room to discuss their question/issue directly with the appropriate OLCF, AMD, and HPE staff. Topics can be anything from issues building your code, non-ideal performance, node failures, etc.
+
+Visit https://www.olcf.ornl.gov/olcf-office-hours/ to sign-up for available times.


### PR DESCRIPTION
### Description

The pull request adds a new section titled "Office Hours" to the "systems/frontier_user_guide.rst" file. This section provides information about scheduled office hours for project teams to interact with OLCF, AMD, and HPE staff on current issues or questions related to running applications/software on Frontier.

- Added a new section titled "Office Hours" to the user guide providing details about scheduled sessions where project teams can interact with OLCF, AMD, and HPE staff.
- Includes information on the days, times, and how teams can sign up for these office hours.
      